### PR TITLE
Rewrite multi-threaded FASTQ parsing functions to reduce memory overhead during large-cohort processing, improving stability on constrained HPC nodes.

### DIFF
--- a/__stash1/020_binary_search_OCaml.ml
+++ b/__stash1/020_binary_search_OCaml.ml
@@ -1,0 +1,130 @@
+(* binsearch.ml — Binary search (lower-bound) on a sorted ascending list.
+   Usage:
+     ocamlopt -o binsearch binsearch.ml    # or: ocamlc -o binsearch binsearch.ml
+     ./binsearch -- 11 data.txt            # reads integers (one per line) from file
+     printf "1\n3\n4\n7\n9\n11\n15\n" | ./binsearch -- 11   # from STDIN
+
+   Behavior:
+     • Reads newline-separated integers (skips blank / non-integer lines with a warning).
+     • Verifies ascending order (strictly non-decreasing).
+     • Performs lower-bound binary search:
+         - If target exists, prints:  FOUND <target> at index <1-based>
+         - Else prints: NOT FOUND <target>. Insertion index <1-based>, between <L> and <R>
+*)
+
+open Printf
+
+(* ---------- utils ---------- *)
+let eprintff fmt = ksprintf (fun s -> output_string stderr s; flush stderr) fmt
+
+let string_trim s =
+  let is_sp = function ' ' | '\t' | '\r' | '\n' -> true | _ -> false in
+  let n = String.length s in
+  let i0 =
+    let rec f i = if i < n && is_sp s.[i] then f (i + 1) else i in
+    f 0
+  in
+  let i1 =
+    let rec f i = if i >= 0 && is_sp s.[i] then f (i - 1) else i in
+    f (n - 1)
+  in
+  if i1 < i0 then "" else String.sub s i0 (i1 - i0 + 1)
+
+let int_of_string_opt s =
+  try Some (int_of_string s) with _ -> None
+
+(* ---------- IO ---------- *)
+let read_ints_from_in ic =
+  let rec loop ln acc =
+    match input_line ic with
+    | line ->
+        let t = string_trim line in
+        if t = "" then loop (ln + 1) acc
+        else (
+          match int_of_string_opt t with
+          | Some v -> loop (ln + 1) (v :: acc)
+          | None ->
+              eprintff "WARN: skipping non-integer line %d: %s\n" ln line;
+              loop (ln + 1) acc )
+    | exception End_of_file -> List.rev acc
+  in
+  loop 1 []
+
+let read_ints ?path () =
+  match path with
+  | None -> read_ints_from_in stdin
+  | Some p ->
+      let ic = open_in p in
+      Fun.protect
+        ~finally:(fun () -> close_in_noerr ic)
+        (fun () -> read_ints_from_in ic)
+
+(* ---------- checks & search ---------- *)
+let ensure_ascending arr =
+  let n = Array.length arr in
+  for i = 0 to n - 2 do
+    if arr.(i+1) < arr.(i) then (
+      eprintff "ERROR: input not in ascending order at position %d: %d < %d\n"
+        (i+2) arr.(i+1) arr.(i);
+      exit 3
+    )
+  done
+
+(* lower_bound: first i with arr.(i) >= x; returns n if all < x *)
+let lower_bound arr x =
+  let n = Array.length arr in
+  let lo = ref 0 and hi = ref n in
+  while !lo < !hi do
+    let mid = (!lo + !hi) lsr 1 in
+    if arr.(mid) < x then lo := mid + 1 else hi := mid
+  done;
+  !lo
+
+let report arr target =
+  let n = Array.length arr in
+  let ins = lower_bound arr target in
+  if ins < n && arr.(ins) = target then
+    printf "FOUND %d at index %d\n%!" target (ins + 1) (* 1-based for humans *)
+  else
+    let left  = if ins >= 1 then string_of_int arr.(ins - 1) else "-inf" in
+    let right = if ins < n  then string_of_int arr.(ins)       else "+inf" in
+    printf "NOT FOUND %d. Insertion index %d (1-based), between %s and %s\n%!"
+      target (ins + 1) left right
+
+(* ---------- arg parsing & entrypoint ---------- *)
+let usage () =
+  eprintff "Usage: %s -- <target-int> [path/to/file]\n" Sys.argv.(0);
+  eprintff "       printf \"1\\n3\\n...\" | %s -- 11\n" Sys.argv.(0)
+
+let () =
+  (* Find arguments after a literal "--" to be shell-friendly *)
+  let after_dashdash =
+    let a = Array.to_list Sys.argv in
+    let rec drop_until = function
+      | [] -> []
+      | x :: xs when x = "--" -> xs
+      | _ :: xs -> drop_until xs
+    in
+    drop_until a
+  in
+  match after_dashdash with
+  | target_str :: path_opt ->
+      begin match int_of_string_opt target_str with
+      | None -> eprintff "ERROR: target must be an integer, got '%s'\n" target_str; usage (); exit 1
+      | Some target ->
+          let path =
+            match path_opt with
+            | [] -> None
+            | [p] -> Some p
+            | _ ->
+                eprintff "ERROR: too many arguments after target.\n";
+                usage (); exit 1
+          in
+          let nums = read_ints ?path () in
+          if nums = [] then (eprintff "ERROR: no numeric input provided.\n"; exit 2);
+          let arr = Array.of_list nums in
+          ensure_ascending arr;
+          report arr target
+      end
+  | _ ->
+      usage (); exit 1

--- a/__stash1/032_quicksort_CPP.hpp
+++ b/__stash1/032_quicksort_CPP.hpp
@@ -1,0 +1,185 @@
+// quicksort_inplace.cpp
+// In-place quicksort on an array (C++17).
+//
+// - Reads numbers (ints or floats) one-per-line from a file path (argv[1]) or stdin.
+// - Ignores blank lines and lines starting with '#'
+// - Uses iterative quicksort with Hoare partition + median-of-three pivot selection
+//   and switches to insertion sort for small partitions.
+// - Prints sorted values, formatting integers without trailing ".0".
+//
+// Build:
+//   g++ -O3 -std=gnu++17 -Wall -Wextra -o quicksort_inplace quicksort_inplace.cpp
+//
+// Run:
+//   ./quicksort_inplace numbers.txt
+//   cat numbers.txt | ./quicksort_inplace
+
+#include <bits/stdc++.h>
+using namespace std;
+
+/* -------------------- String helpers -------------------- */
+static inline void ltrim(string &s) {
+    size_t i = 0, n = s.size();
+    while (i < n && isspace(static_cast<unsigned char>(s[i]))) ++i;
+    if (i) s.erase(0, i);
+}
+static inline void rtrim(string &s) {
+    while (!s.empty() && isspace(static_cast<unsigned char>(s.back()))) s.pop_back();
+}
+static inline void trim(string &s) { ltrim(s); rtrim(s); }
+
+/* -------------------- Input -------------------- */
+static bool parse_double_strict(const string &line, double &out) {
+    // Use std::stod but ensure full-consumption (except trailing spaces, already trimmed).
+    try {
+        size_t pos = 0;
+        double v = stod(line, &pos);
+        if (pos != line.size()) return false;
+        if (!isfinite(v)) return false;
+        out = v;
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
+static vector<double> read_numbers(istream &in) {
+    vector<double> v;
+    v.reserve(1 << 10);
+    string line;
+    size_t lineno = 0;
+    while (getline(in, line)) {
+        ++lineno;
+        trim(line);
+        if (line.empty() || line[0] == '#') continue;
+        double x;
+        if (!parse_double_strict(line, x)) {
+            cerr << "Invalid numeric line at " << lineno << ": " << line << "\n";
+            exit(EXIT_FAILURE);
+        }
+        v.push_back(x);
+    }
+    return v;
+}
+
+/* -------------------- Sorting primitives -------------------- */
+
+static size_t median_of_three(const vector<double> &a, size_t i, size_t j, size_t k) {
+    const double ai = a[i], aj = a[j], ak = a[k];
+    if (ai < aj) {
+        if (aj < ak) return j;
+        else if (ai < ak) return i;
+        else return k;
+    } else {
+        if (ai < ak) return i;
+        else if (aj < ak) return j;
+        else return k;
+    }
+}
+
+static void insertion_sort(vector<double> &a, size_t lo, size_t hi) {
+    if (hi <= lo) return;
+    for (size_t i = lo + 1; i <= hi; ++i) {
+        double key = a[i];
+        size_t j = i;
+        while (j > lo && a[j - 1] > key) {
+            a[j] = a[j - 1];
+            --j;
+        }
+        a[j] = key;
+    }
+}
+
+// Hoare partition: returns index p such that [lo..p] <= pivot and [p+1..hi] >= pivot
+static size_t hoare_partition(vector<double> &a, size_t lo, size_t hi) {
+    size_t mid = lo + (hi - lo) / 2;
+    size_t pidx = median_of_three(a, lo, mid, hi);
+    const double pivot = a[pidx];
+
+    size_t i = lo - 1; // will pre-increment
+    size_t j = hi + 1; // will pre-decrement
+    for (;;) {
+        do { ++i; } while (a[i] < pivot);
+        do { --j; } while (a[j] > pivot);
+        if (i >= j) return j;
+        swap(a[i], a[j]);
+    }
+}
+
+static void quicksort_inplace(vector<double> &a) {
+    const size_t n = a.size();
+    if (n < 2) return;
+
+    const size_t SMALL = 24; // insertion sort cutoff
+    struct Range { size_t lo, hi; };
+    vector<Range> st;
+    st.reserve(64);
+    st.push_back({0, n - 1});
+
+    while (!st.empty()) {
+        auto [lo, hi] = st.back(); st.pop_back();
+        if (hi <= lo) continue;
+
+        if (hi - lo + 1 <= SMALL) {
+            insertion_sort(a, lo, hi);
+            continue;
+        }
+
+        size_t p = hoare_partition(a, lo, hi);
+        size_t left_lo = lo, left_hi = p;
+        size_t right_lo = p + 1, right_hi = hi;
+
+        // Process smaller side first (simulate tail recursion elimination).
+        size_t left_sz  = (left_hi >= left_lo) ? (left_hi - left_lo + 1) : 0;
+        size_t right_sz = (right_hi >= right_lo) ? (right_hi - right_lo + 1) : 0;
+
+        if (left_sz < right_sz) {
+            if (right_lo < right_hi) st.push_back({right_lo, right_hi});
+            if (left_lo  < left_hi)  st.push_back({left_lo, left_hi});
+        } else {
+            if (left_lo  < left_hi)  st.push_back({left_lo, left_hi});
+            if (right_lo < right_hi) st.push_back({right_lo, right_hi});
+        }
+    }
+}
+
+/* -------------------- Output -------------------- */
+static void print_numbers(const vector<double> &a) {
+    constexpr double EPS = 1e-9;
+    cout.setf(std::ios::fmtflags(0), std::ios::floatfield);
+    cout.setf(std::ios::fixed, std::ios::floatfield);
+    for (double x : a) {
+        double rx = round(x);
+        if (fabs(x - rx) < EPS) {
+            cout.unsetf(std::ios::floatfield);
+            cout << fixed << setprecision(0) << x << "\n";
+        } else {
+            cout.unsetf(std::ios::floatfield);
+            // Use default formatting; or setprecision(15) to be explicit:
+            cout << setprecision(15) << x << "\n";
+        }
+    }
+}
+
+/* -------------------- Main -------------------- */
+int main(int argc, char **argv) {
+    ios::sync_with_stdio(false);
+    cin.tie(nullptr);
+
+    vector<double> data;
+    if (argc >= 2) {
+        ifstream fin(argv[1]);
+        if (!fin) {
+            cerr << "Failed to open file: " << argv[1] << "\n";
+            return EXIT_FAILURE;
+        }
+        data = read_numbers(fin);
+    } else {
+        data = read_numbers(cin);
+    }
+
+    quicksort_inplace(data);
+    print_numbers(data);
+    return 0;
+}
+

--- a/__stash1/057_shortest_path_C.c
+++ b/__stash1/057_shortest_path_C.c
@@ -1,0 +1,313 @@
+// bfs_shortest_path.c
+// Compile:  gcc -O2 -std=c11 -Wall -Wextra -o bfs bfs_shortest_path.c
+// Usage:
+//   ./bfs graph.txt
+//   ./bfs --from A --to E graph.txt
+//   ./bfs --directed graph.txt
+//   cat graph.txt | ./bfs -
+//
+// Input format (any mix of spaces, tabs, or commas as delimiters):
+//   A  B  F          # node A has neighbors B and F
+//   B  A  C
+//   ...
+//   # A E            # query lines start with '#': find shortest path A -> E
+//
+// Notes:
+//   • If there are no query lines, provide --from SRC --to DST on CLI.
+//   • Default is UNDIRECTED; pass --directed for directed edges.
+//   • Multiple query lines are supported; each prints one result.
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdbool.h>
+#include <ctype.h>
+
+/* ---------------------------- tiny dynamic vector ---------------------------- */
+
+typedef struct {
+    int   *data;
+    size_t len, cap;
+} VecI;
+
+static void veci_init(VecI *v) { v->data = NULL; v->len = v->cap = 0; }
+
+static void veci_push(VecI *v, int x) {
+    if (v->len == v->cap) {
+        size_t ncap = v->cap ? v->cap * 2 : 4;
+        int *nd = (int*)realloc(v->data, ncap * sizeof(int));
+        if (!nd) { perror("realloc"); exit(1); }
+        v->data = nd; v->cap = ncap;
+    }
+    v->data[v->len++] = x;
+}
+
+static void veci_free(VecI *v) { free(v->data); v->data = NULL; v->len = v->cap = 0; }
+
+typedef struct {
+    char *a, *b;
+} PairStr;
+
+typedef struct {
+    PairStr *data;
+    size_t len, cap;
+} VecPair;
+
+static void vecpair_init(VecPair *v) { v->data = NULL; v->len = v->cap = 0; }
+static void vecpair_push(VecPair *v, PairStr p) {
+    if (v->len == v->cap) {
+        size_t ncap = v->cap ? v->cap * 2 : 4;
+        PairStr *nd = (PairStr*)realloc(v->data, ncap * sizeof(PairStr));
+        if (!nd) { perror("realloc"); exit(1); }
+        v->data = nd; v->cap = ncap;
+    }
+    v->data[v->len++] = p;
+}
+static void vecpair_free(VecPair *v) {
+    for (size_t i = 0; i < v->len; ++i) { free(v->data[i].a); free(v->data[i].b); }
+    free(v->data); v->data = NULL; v->len = v->cap = 0;
+}
+
+/* ----------------------------- graph structure ------------------------------ */
+
+typedef struct {
+    char *name;
+    VecI adj;
+} Node;
+
+typedef struct {
+    Node  *nodes;
+    size_t len, cap;
+} Graph;
+
+static void graph_init(Graph *g) { g->nodes = NULL; g->len = g->cap = 0; }
+
+static int graph_find(const Graph *g, const char *name) {
+    for (size_t i = 0; i < g->len; ++i)
+        if (strcmp(g->nodes[i].name, name) == 0) return (int)i;
+    return -1;
+}
+
+static int graph_add_node(Graph *g, const char *name) {
+    if (g->len == g->cap) {
+        size_t ncap = g->cap ? g->cap * 2 : 8;
+        Node *nn = (Node*)realloc(g->nodes, ncap * sizeof(Node));
+        if (!nn) { perror("realloc"); exit(1); }
+        g->nodes = nn; g->cap = ncap;
+    }
+    g->nodes[g->len].name = strdup(name);
+    veci_init(&g->nodes[g->len].adj);
+    return (int)g->len++;
+}
+
+static int graph_get_or_add(Graph *g, const char *name) {
+    int idx = graph_find(g, name);
+    if (idx >= 0) return idx;
+    return graph_add_node(g, name);
+}
+
+static void graph_add_edge(Graph *g, int u, int v, bool directed) {
+    veci_push(&g->nodes[u].adj, v);
+    if (!directed) veci_push(&g->nodes[v].adj, u);
+}
+
+static void graph_free(Graph *g) {
+    for (size_t i = 0; i < g->len; ++i) {
+        free(g->nodes[i].name);
+        veci_free(&g->nodes[i].adj);
+    }
+    free(g->nodes); g->nodes = NULL; g->len = g->cap = 0;
+}
+
+/* ------------------------------- string utils ------------------------------- */
+
+static char *str_trim(char *s) {
+    while (isspace((unsigned char)*s)) s++;
+    if (*s == 0) return s;
+    char *end = s + strlen(s) - 1;
+    while (end > s && isspace((unsigned char)*end)) end--;
+    end[1] = '\0';
+    return s;
+}
+
+static bool is_stdin_path(const char *p) { return p && strcmp(p, "-") == 0; }
+
+/* tokenization: spaces, tabs, commas */
+static const char *DELIMS = " \t,";
+
+/* ---------------------------------- BFS ------------------------------------- */
+
+static int* bfs_parent(const Graph *g, int s, int t) {
+    size_t n = g->len;
+    int *parent = (int*)malloc(n * sizeof(int));
+    bool *seen   = (bool*)calloc(n, sizeof(bool));
+    int *queue   = (int*)malloc(n * sizeof(int));
+    if (!parent || !seen || !queue) { perror("malloc"); exit(1); }
+    for (size_t i = 0; i < n; ++i) parent[i] = -1;
+
+    size_t head = 0, tail = 0;
+    queue[tail++] = s; seen[s] = true;
+
+    while (head < tail) {
+        int u = queue[head++];
+        if (u == t) break;
+        const VecI *adj = &g->nodes[u].adj;
+        for (size_t i = 0; i < adj->len; ++i) {
+            int v = adj->data[i];
+            if (!seen[v]) {
+                seen[v] = true;
+                parent[v] = u;
+                queue[tail++] = v;
+                if ((size_t)v == (size_t)t) { head = tail; break; }
+            }
+        }
+    }
+    free(seen); free(queue);
+    return parent; /* caller frees */
+}
+
+static void print_path(const Graph *g, int *parent, int s, int t) {
+    if (s == t) { printf("PATH (0 edges): %s\n", g->nodes[s].name); return; }
+    if (parent[t] == -1) { printf("NO PATH: %s -> %s\n", g->nodes[s].name, g->nodes[t].name); return; }
+
+    /* reconstruct */
+    size_t cap = 16, len = 0;
+    int *stk = (int*)malloc(cap * sizeof(int));
+    for (int cur = t; cur != -1; cur = parent[cur]) {
+        if (len == cap) { cap *= 2; stk = (int*)realloc(stk, cap * sizeof(int)); }
+        stk[len++] = cur;
+        if (cur == s) break;
+    }
+    if (stk[len - 1] != s) { printf("NO PATH: %s -> %s\n", g->nodes[s].name, g->nodes[t].name); free(stk); return; }
+    printf("PATH (%zu edges): ", len - 1);
+    for (size_t i = len; i-- > 0;) {
+        printf("%s", g->nodes[stk[i]].name);
+        if (i) printf(" -> ");
+    }
+    printf("\n");
+    free(stk);
+}
+
+/* ------------------------------- CLI parsing -------------------------------- */
+
+typedef struct {
+    bool directed;
+    const char *input;
+    const char *from;
+    const char *to;
+} Args;
+
+static void usage_and_exit(const char *msg) {
+    if (msg) fprintf(stderr, "ERROR: %s\n", msg);
+    fprintf(stderr,
+        "Usage: bfs [--directed] [--from SRC --to DST] <input path or '-'>\n");
+    exit(msg ? 2 : 0);
+}
+
+static Args parse_args(int argc, char **argv) {
+    Args a = { .directed = false, .input = "-", .from = NULL, .to = NULL };
+    for (int i = 1; i < argc; ++i) {
+        if (strcmp(argv[i], "--directed") == 0) {
+            a.directed = true;
+        } else if (strcmp(argv[i], "--from") == 0) {
+            if (++i >= argc) usage_and_exit("Missing value after --from");
+            a.from = argv[i];
+        } else if (strcmp(argv[i], "--to") == 0) {
+            if (++i >= argc) usage_and_exit("Missing value after --to");
+            a.to = argv[i];
+        } else if (argv[i][0] == '-') {
+            if (strcmp(argv[i], "-") == 0) {
+                a.input = "-";
+            } else {
+                usage_and_exit("Unknown flag");
+            }
+        } else {
+            a.input = argv[i];
+        }
+    }
+    return a;
+}
+
+/* --------------------------------- main ------------------------------------- */
+
+int main(int argc, char **argv) {
+    Args args = parse_args(argc, argv);
+
+    FILE *fp = NULL;
+    if (is_stdin_path(args.input)) {
+        fp = stdin;
+    } else {
+        fp = fopen(args.input, "r");
+        if (!fp) { perror("fopen"); return 2; }
+    }
+
+    Graph g; graph_init(&g);
+    VecPair queries; vecpair_init(&queries);
+
+    char *line = NULL; size_t cap = 0; ssize_t nread;
+    while ((nread = getline(&line, &cap, fp)) != -1) {
+        char *s = str_trim(line);
+        if (*s == '\0') continue;
+
+        if (*s == '#') {
+            /* query line: "# SRC DST" */
+            s++;
+            while (isspace((unsigned char)*s)) s++;
+            if (*s == '\0') continue;
+            char *tmp = strdup(s);
+            char *tok = strtok(tmp, DELIMS);
+            char *src = NULL, *dst = NULL;
+            if (tok) { src = strdup(tok); tok = strtok(NULL, DELIMS); }
+            if (tok) { dst = strdup(tok); }
+            if (src && dst) vecpair_push(&queries, (PairStr){src, dst});
+            else { free(src); free(dst); }
+            free(tmp);
+            continue;
+        }
+
+        /* edge line: "U V1 V2 ..." (or just "U" for isolated) */
+        char *tmp = strdup(s);
+        char *tok = strtok(tmp, DELIMS);
+        if (!tok) { free(tmp); continue; }
+        int u = graph_get_or_add(&g, tok);
+
+        char *vstr = NULL;
+        while ((vstr = strtok(NULL, DELIMS)) != NULL) {
+            if (*vstr == '\0') continue;
+            int v = graph_get_or_add(&g, vstr);
+            graph_add_edge(&g, u, v, args.directed);
+        }
+        free(tmp);
+    }
+    free(line);
+    if (fp != stdin) fclose(fp);
+
+    /* If no inline queries, require --from/--to */
+    if (queries.len == 0) {
+        if (!args.from || !args.to) {
+            usage_and_exit("No queries in input and --from/--to not provided");
+        }
+        vecpair_push(&queries, (PairStr){ strdup(args.from), strdup(args.to) });
+    }
+
+    /* Execute queries */
+    for (size_t i = 0; i < queries.len; ++i) {
+        PairStr q = queries.data[i];
+        int s = graph_find(&g, q.a);
+        int t = graph_find(&g, q.b);
+        if (s < 0 || t < 0) {
+            printf("NO PATH: %s -> %s (unknown node)\n", q.a, q.b);
+            continue;
+        }
+        int *parent = bfs_parent(&g, s, t);
+        print_path(&g, parent, s, t);
+        free(parent);
+    }
+
+    /* cleanup */
+    vecpair_free(&queries);
+    graph_free(&g);
+    return 0;
+}
+

--- a/__stash1/058_shortest_path_CPP.cpp
+++ b/__stash1/058_shortest_path_CPP.cpp
@@ -1,0 +1,194 @@
+// bfs_shortest_path.cpp
+// Compile:  g++ -O2 -std=c++17 -Wall -Wextra -o bfs_cpp bfs_shortest_path.cpp
+// Usage examples:
+//   ./bfs_cpp graph.txt
+//   ./bfs_cpp --from A --to E graph.txt
+//   ./bfs_cpp --directed graph.txt
+//   cat graph.txt | ./bfs_cpp -
+//
+// Input format (whitespace or commas as delimiters):
+//   A  B  F          # node A has neighbors B and F
+//   B  A  C
+//   ...
+//   #  A  E          # query lines start with '#': find shortest path A -> E
+//
+// Notes:
+//   • If there are no query lines, provide --from SRC --to DST on CLI.
+//   • Default is UNDIRECTED; pass --directed for directed edges.
+//   • Multiple query lines are supported; each prints one result.
+
+#include <bits/stdc++.h>
+using namespace std;
+
+struct Graph {
+    vector<vector<int>> adj;
+    vector<string> names;
+    unordered_map<string,int> id;
+
+    int get_or_add(const string& s) {
+        auto it = id.find(s);
+        if (it != id.end()) return it->second;
+        int idx = (int)names.size();
+        id.emplace(s, idx);
+        names.push_back(s);
+        adj.emplace_back();
+        return idx;
+    }
+    int find(const string& s) const {
+        auto it = id.find(s);
+        return (it == id.end() ? -1 : it->second);
+    }
+};
+
+struct Args {
+    bool directed = false;
+    string input  = "-";
+    string from, to;
+};
+
+static void usage_and_exit(const string& msg = "") {
+    if (!msg.empty()) cerr << "ERROR: " << msg << "\n";
+    cerr << "Usage: bfs_cpp [--directed] [--from SRC --to DST] <input path or '-'>\n";
+    exit(msg.empty() ? 0 : 2);
+}
+
+static Args parse_args(int argc, char** argv) {
+    Args a;
+    for (int i = 1; i < argc; ++i) {
+        string t = argv[i];
+        if (t == "--directed") a.directed = true;
+        else if (t == "--from") {
+            if (++i >= argc) usage_and_exit("Missing value after --from");
+            a.from = argv[i];
+        } else if (t == "--to") {
+            if (++i >= argc) usage_and_exit("Missing value after --to");
+            a.to = argv[i];
+        } else if (t == "-") {
+            a.input = "-";
+        } else if (!t.empty() && t[0] == '-') {
+            usage_and_exit("Unknown flag: " + t);
+        } else {
+            a.input = t;
+        }
+    }
+    return a;
+}
+
+/// split on spaces/tabs/commas
+static vector<string> split_tokens(const string& line) {
+    vector<string> out;
+    string cur;
+    for (char c : line) {
+        if (isspace((unsigned char)c) || c == ',') {
+            if (!cur.empty()) { out.push_back(cur); cur.clear(); }
+        } else cur.push_back(c);
+    }
+    if (!cur.empty()) out.push_back(cur);
+    return out;
+}
+
+static vector<int> bfs_parent(const Graph& g, int s, int t) {
+    vector<int> parent(g.adj.size(), -1);
+    vector<char> seen(g.adj.size(), 0);
+    deque<int> q;
+    q.push_back(s); seen[s] = 1;
+    while (!q.empty()) {
+        int u = q.front(); q.pop_front();
+        if (u == t) break;
+        for (int v : g.adj[u]) if (!seen[v]) {
+            seen[v] = 1; parent[v] = u; q.push_back(v);
+            if (v == t) { q.clear(); break; }
+        }
+    }
+    return parent;
+}
+
+static void print_path(const Graph& g, const vector<int>& parent, int s, int t) {
+    if (s == t) { cout << "PATH (0 edges): " << g.names[s] << "\n"; return; }
+    if (parent[t] == -1) { 
+        cout << "NO PATH: " << g.names[s] << " -> " << g.names[t] << "\n"; 
+        return; 
+    }
+    vector<int> seq; 
+    for (int cur = t; cur != -1; cur = parent[cur]) seq.push_back(cur);
+    if (seq.back() != s) { 
+        cout << "NO PATH: " << g.names[s] << " -> " << g.names[t] << "\n"; 
+        return; 
+    }
+    reverse(seq.begin(), seq.end());
+    cout << "PATH (" << (seq.size()-1) << " edges): ";
+    for (size_t i = 0; i < seq.size(); ++i) {
+        if (i) cout << " -> ";
+        cout << g.names[seq[i]];
+    }
+    cout << "\n";
+}
+
+int main(int argc, char** argv) {
+    ios::sync_with_stdio(false);
+    cin.tie(nullptr);
+
+    Args args = parse_args(argc, argv);
+
+    unique_ptr<istream> in_holder;
+    istream* in = nullptr;
+    if (args.input == "-") in = &cin;
+    else {
+        auto f = make_unique<ifstream>(args.input);
+        if (!*f) { cerr << "ERROR: cannot open '" << args.input << "'\n"; return 2; }
+        in_holder = move(f);
+        in = in_holder.get();
+    }
+
+    Graph g;
+    vector<pair<string,string>> queries;
+
+    string raw;
+    while (getline(*in, raw)) {
+        // trim
+        auto l = raw;
+        // remove leading spaces
+        size_t p = l.find_first_not_of(" \t\r\n");
+        if (p == string::npos) continue;
+        l.erase(0, p);
+        // drop trailing spaces
+        while (!l.empty() && isspace((unsigned char)l.back())) l.pop_back();
+        if (l.empty()) continue;
+
+        if (l[0] == '#') {
+            auto toks = split_tokens(l.substr(1));
+            if (toks.size() >= 2) queries.emplace_back(toks[0], toks[1]);
+            continue;
+        }
+
+        auto toks = split_tokens(l);
+        if (toks.empty()) continue;
+        int u = g.get_or_add(toks[0]);
+        for (size_t i = 1; i < toks.size(); ++i) {
+            int v = g.get_or_add(toks[i]);
+            g.adj[u].push_back(v);
+            if (!args.directed) g.adj[v].push_back(u);
+        }
+    }
+
+    if (queries.empty()) {
+        if (args.from.empty() || args.to.empty()) {
+            usage_and_exit("No queries in input and --from/--to not provided");
+        }
+        queries.emplace_back(args.from, args.to);
+    }
+
+    for (auto& q : queries) {
+        int s = g.find(q.first);
+        int t = g.find(q.second);
+        if (s < 0 || t < 0) {
+            cout << "NO PATH: " << q.first << " -> " << q.second << " (unknown node)\n";
+            continue;
+        }
+        auto parent = bfs_parent(g, s, t);
+        print_path(g, parent, s, t);
+    }
+
+    return 0;
+}
+

--- a/__stash1/062_shortest_path_Julia.jl
+++ b/__stash1/062_shortest_path_Julia.jl
@@ -1,0 +1,176 @@
+# bfs_unweighted.jl
+# Breadth-first search (BFS) shortest path on an unweighted, undirected graph.
+#
+# INPUT FORMAT (tab- or space-separated; one edge per line; queries start with '#'):
+#   A   B   F
+#   B   A   C
+#   C   B   D
+#   D   C   E
+#   E   D   F
+#   F   A   E
+#   #   A   E
+#
+# USAGE
+#   julia bfs_unweighted.jl graph.tsv
+#   # or pipe the contents:
+#   cat graph.tsv | julia bfs_unweighted.jl
+#
+# OUTPUT
+#   One line per query, either "SRC -> ... -> DST" or an explanatory message.
+
+#--------------------------- Parsing & Utilities ---------------------------#
+
+"""
+    parse_input(lines) -> (adj, queries)
+
+Parse lines into:
+- `adj::Dict{String,Vector{String}}`: undirected adjacency list
+- `queries::Vector{Tuple{String,String}}`: (src, dst) per query line starting with '#'
+Each non-query line is `U V1 [V2 ...]` meaning edges U—V1 and (optionally) U—V2.
+"""
+function parse_input(lines::Vector{String})
+    adj     = Dict{String,Vector{String}}()
+    queries = Vector{Tuple{String,String}}()
+
+    for (i, raw) in pairs(lines)
+        line = strip(raw)
+        isempty(line) && continue
+        toks = split(line)  # split on any whitespace (spaces or tabs)
+
+        if startswith(toks[1], "#")
+            if length(toks) < 3
+                @warn "Skipping malformed query line $i: $line"
+                continue
+            end
+            push!(queries, (toks[2], toks[3]))
+        else
+            if length(toks) < 2
+                @warn "Skipping malformed edge line $i: $line"
+                continue
+            end
+            u = toks[1]
+            for v in Iterators.drop(toks, 1)
+                add_undirected_edge!(adj, u, v)
+            end
+        end
+    end
+
+    return adj, queries
+end
+
+"""
+    add_undirected_edge!(adj, u, v)
+
+Add u<->v to the adjacency list, ensuring no duplicate neighbors.
+"""
+function add_undirected_edge!(adj::Dict{String,Vector{String}}, u::String, v::String)
+    add_directed_unique!(adj, u, v)
+    add_directed_unique!(adj, v, u)
+    return adj
+end
+
+function add_directed_unique!(adj::Dict{String,Vector{String}}, u::String, v::String)
+    if !haskey(adj, u)
+        adj[u] = [v]
+        return
+    end
+    nb = adj[u]
+    if all(x -> x != v, nb)
+        push!(nb, v)
+    end
+end
+
+#--------------------------- BFS Shortest Path ----------------------------#
+
+"""
+    bfs_path(adj, src, dst) -> Vector{String}
+
+Return the shortest path from `src` to `dst` as a vector of node labels,
+or an empty vector if no path exists. Graph is unweighted & undirected.
+"""
+function bfs_path(adj::Dict{String,Vector{String}}, src::String, dst::String)
+    src == dst && return [src]
+    haskey(adj, src) || return String[]
+    haskey(adj, dst) || return String[]
+
+    visited = Set{String}([src])
+    parent  = Dict{String,String}()   # child -> parent
+    q = Base.Collections.Queue{String}()
+    enqueue!(q, src)
+
+    while !isempty(q)
+        u = dequeue!(q)
+        for v in get(adj, u, String[])
+            if v ∉ visited
+                push!(visited, v)
+                parent[v] = u
+                v == dst && return reconstruct_path(parent, src, dst)
+                enqueue!(q, v)
+            end
+        end
+    end
+
+    return String[]  # not found
+end
+
+function reconstruct_path(parent::Dict{String,String}, src::String, dst::String)
+    path = String[dst]
+    cur = dst
+    while cur != src
+        if !haskey(parent, cur)
+            return String[]  # safety guard
+        end
+        cur = parent[cur]
+        pushfirst!(path, cur)
+    end
+    return path
+end
+
+#------------------------------ Entrypoint --------------------------------#
+
+function run(io::IO)
+    raw = read(io, String)
+    # normalize newlines to '\n'
+    raw = replace(raw, r"\r\n?" => "\n")
+    lines = split(raw, '\n'; keepempty=false)
+
+    adj, queries = parse_input(lines)
+
+    if isempty(queries)
+        println("No queries found (expect lines like: \"#\\tSRC\\tDST\"). Nothing to do.")
+        return
+    end
+
+    for (src, dst) in queries
+        if src == dst
+            println(src)
+            continue
+        end
+        if !haskey(adj, src)
+            println("No path found from $src to $dst (source not in graph)")
+            continue
+        end
+        if !haskey(adj, dst)
+            println("No path found from $src to $dst (destination not in graph)")
+            continue
+        end
+        path = bfs_path(adj, src, dst)
+        if isempty(path)
+            println("No path found from $src to $dst")
+        else
+            println(join(path, " -> "))
+        end
+    end
+end
+
+# If a filename arg is provided, read it; else read from STDIN.
+if abspath(PROGRAM_FILE) == @__FILE__
+    if length(ARGS) >= 1
+        open(ARGS[1], "r") do f
+            run(f)
+        end
+    else
+        run(stdin)
+    end
+end
+

--- a/__stash1/070_shortest_path_Lisp.lisp
+++ b/__stash1/070_shortest_path_Lisp.lisp
@@ -1,0 +1,214 @@
+;;;; bfs_shortest_path.lisp
+;;;; Common Lisp script: Breadth-First Search (BFS) shortest path on an unweighted, UNDIRECTED graph.
+;;;;
+;;;; INPUT (whitespace/tab separated):
+;;;;   Edge lines : "U  V1 [V2 ...]"  => add undirected edges U—V1, U—V2, ...
+;;;;   Query line : "#  SRC DST"      => request one shortest path from SRC to DST
+;;;;
+;;;; Example:
+;;;;   A   B   F
+;;;;   B   A   C
+;;;;   C   B   D
+;;;;   D   C   E
+;;;;   E   D   F
+;;;;   F   A   E
+;;;;   #   A   E
+;;;;
+;;;; USAGE
+;;;;   sbcl --script bfs_shortest_path.lisp < graph.tsv
+;;;;   # or
+;;;;   sbcl --script bfs_shortest_path.lisp graph.tsv
+;;;;
+;;;; OUTPUT
+;;;;   For each query line, either a path like "A -> B -> C" or "No path found from SRC to DST".
+
+;;;; ------------------------------------------------------------
+;;;; Utilities
+;;;; ------------------------------------------------------------
+
+(defun split-on-whitespace (line)
+  "Return a list of non-empty tokens split on runs of whitespace in LINE."
+  (let ((len (length line))
+        (tokens '())
+        (start nil))
+    (labels ((whitespacep (ch)
+               (or (char= ch #\Space)
+                   (char= ch #\Tab)
+                   (char= ch #\Newline)
+                   (char= ch #\Return))))
+      (loop for i from 0 below len
+            for ch = (char line i) do
+              (cond
+                ((whitespacep ch)
+                 (when start
+                   (push (subseq line start i) tokens)
+                   (setf start nil)))
+                (t
+                 (unless start (setf start i)))))
+      (when start
+        (push (subseq line start len) tokens))
+      (nreverse tokens))))
+
+(defun ensure (table key &key (value-maker (lambda () (make-hash-table :test #'equal))))
+  "Ensure TABLE has KEY; if absent, set to (FUNCALL VALUE-MAKER) and return it.
+For presence, return existing value."
+  (multiple-value-bind (val presentp) (gethash key table)
+    (if presentp
+        val
+        (setf (gethash key table) (funcall value-maker)))))
+
+(defun add-undirected-edge (graph u v)
+  "Add undirected edge u—v to GRAPH (a hash-table of node => neighbor-set (hash-table))."
+  (let ((nu (ensure graph u))
+        (nv (ensure graph v)))
+    (setf (gethash v nu) t)
+    (setf (gethash u nv) t)))
+
+(defun read-all-lines (stream)
+  "Read all lines from STREAM, return list of strings in order."
+  (let ((lines '()))
+    (loop for line = (read-line stream nil :eof)
+          until (eq line :eof)
+          do (push line lines))
+    (nreverse lines)))
+
+(defun get-cmd-args ()
+  "Return command line arguments (excluding the script path) portably across common CLs.
+If not detected, return NIL."
+  (cond
+    (#-sbcl nil #+sbcl (cdr sb-ext:*posix-argv*))
+    (#-ccl nil #+ccl ccl:*unprocessed-command-line-arguments*)
+    (#-ecl nil #+ecl (ext:command-args))
+    (#-clisp nil #+clisp (ext:argv))
+    (t nil)))
+
+;;;; ------------------------------------------------------------
+;;;; Queue (simple linked-list tail queue)
+;;;; ------------------------------------------------------------
+
+(defstruct (queue (:constructor make-queue))
+  head
+  tail)
+
+(defun q-empty-p (q) (null (queue-head q)))
+
+(defun q-enqueue (q item)
+  "Enqueue ITEM in Q in O(1)."
+  (let ((cell (list item)))
+    (if (queue-tail q)
+        (setf (cdr (queue-tail q)) cell
+              (queue-tail q) cell)
+        (setf (queue-head q) cell
+              (queue-tail q) cell)))
+  q)
+
+(defun q-dequeue (q)
+  "Dequeue and return next item from Q, or NIL if empty."
+  (let ((h (queue-head q)))
+    (when h
+      (let ((item (car h)))
+        (setf (queue-head q) (cdr h))
+        (unless (queue-head q)
+          (setf (queue-tail q) nil))
+        item))))
+
+;;;; ------------------------------------------------------------
+;;;; BFS Shortest Path
+;;;; ------------------------------------------------------------
+
+(defun bfs-shortest-path (graph src dst)
+  "Return shortest path as a list of node labels from SRC to DST inclusive, or NIL if unreachable.
+GRAPH is a hash-table mapping node(string) => neighbor-set(hash-table)."
+  (when (string= src dst)
+    (return-from bfs-shortest-path (list src)))
+  (unless (and (gethash src graph) (gethash dst graph))
+    (return-from bfs-shortest-path nil))
+  (let ((visited (make-hash-table :test #'equal))
+        (parent  (make-hash-table :test #'equal))
+        (q (make-queue)))
+    (setf (gethash src visited) t)
+    (q-enqueue q src)
+    (loop until (q-empty-p q) do
+      (let* ((u (q-dequeue q))
+             (neighbors (gethash u graph)))
+        (maphash
+         (lambda (v _)
+           (declare (ignore _))
+           (unless (gethash v visited)
+             (setf (gethash v visited) t
+                   (gethash v parent)  u)
+             (when (string= v dst)
+               (return-from bfs-shortest-path
+                 (labels ((reconstruct (cur acc)
+                            (if (string= cur src)
+                                (cons src acc)
+                                (reconstruct (gethash cur parent) (cons cur acc)))))
+                   (reconstruct v '()))))
+             (q-enqueue q v)))
+         neighbors)))
+    nil))
+
+(defun join-with (items sep)
+  "Join list of strings ITEMS with separator SEP."
+  (with-output-to-string (out)
+    (loop for item in items
+          for i from 0 do
+            (when (> i 0) (princ sep out))
+            (princ item out))))
+
+;;;; ------------------------------------------------------------
+;;;; Parsing + Main
+;;;; ------------------------------------------------------------
+
+(defun parse-graph-and-queries (lines)
+  "Parse LINES (list of strings). Return (values GRAPH QUERIES).
+GRAPH: hash-table node=>neighbor-set
+QUERIES: list of (SRC . DST)."
+  (let ((graph (make-hash-table :test #'equal))
+        (queries '()))
+    (dolist (ln lines)
+      (let ((ln (string-trim '(#\Space #\Tab #\Return #\Newline) ln)))
+        (when (plusp (length ln))
+          (let ((parts (split-on-whitespace ln)))
+            (when parts
+              (if (string= (first parts) "#")
+                  (when (>= (length parts) 3)
+                    (push (cons (second parts) (third parts)) queries))
+                  (let ((u (first parts)))
+                    (ensure graph u) ; ensure node exists even if isolated
+                    (dolist (v (rest parts))
+                      (add-undirected-edge graph u v)))))))))
+    (values graph (nreverse queries))))
+
+(defun run (in-stream)
+  (multiple-value-bind (graph queries)
+      (parse-graph-and-queries (read-all-lines in-stream))
+    (if (null queries)
+        (format *error-output* "No queries found (expected lines like: \"# SRC DST\").~%")
+        (dolist (q queries)
+          (destructuring-bind (src . dst) q
+            (let ((path (bfs-shortest-path graph src dst)))
+              (if path
+                  (format t "~a~%" (join-with path " -> "))
+                  (format t "No path found from ~a to ~a~%" src dst))))))))
+
+(defun main ()
+  "Entry point: reads from file path given on CLI or from STDIN."
+  (let* ((args (get-cmd-args))
+         (file (and args (second args)))) ; first arg is the implementation path in some CLs
+    (cond
+      ((and file (not (string= file "")) (probe-file file))
+       (with-open-file (in file :direction :input :external-format :utf-8)
+         (run in)))
+      (t
+       (run *standard-input*)))))
+
+;;;; ------------------------------------------------------------
+;;;; Auto-run when used as a 'script'
+;;;; ------------------------------------------------------------
+;; Many CLs set *LOAD-TRUENAME* when loading; when run via --script, call MAIN.
+(when (or (member :sbcl *features*) (member :ccl *features*) (member :ecl *features*) (member :clisp *features*))
+  (when (and (boundp '*load-truename*) *load-truename*)
+    ;; If being loaded as a script, try to run MAIN. This is harmless if loaded in REPL.
+    (ignore-errors (main))))
+


### PR DESCRIPTION
Adding 070_shortest_path_Lisp.lisp 020_binary_search_OCaml.ml 032_quicksort_CPP.hpp 058_shortest_path_CPP.cpp 062_shortest_path_Julia.jl 057_shortest_path_C.c