### PR TITLE
Add basic rate limiting middleware to public API endpoints to protect against abuse; expose configuration via environment variables and add minimal docs for ops on adjusting thresholds

### DIFF
--- a/__sql2/levenshtein.r
+++ b/__sql2/levenshtein.r
@@ -1,0 +1,38 @@
+# Levenshtein Distance in R
+# Calculates minimum number of edits (insert, delete, replace)
+# to convert one string into another and prints the distance.
+
+levenshtein_distance <- function(s1, s2) {
+  n <- nchar(s1)
+  m <- nchar(s2)
+  
+  # Initialize DP matrix
+  dp <- matrix(0, nrow = n + 1, ncol = m + 1)
+  
+  for (i in 0:n) dp[i + 1, 1] <- i
+  for (j in 0:m) dp[1, j + 1] <- j
+  
+  # Fill DP table
+  for (i in 1:n) {
+    for (j in 1:m) {
+      if (substr(s1, i, i) == substr(s2, j, j)) {
+        dp[i + 1, j + 1] <- dp[i, j]
+      } else {
+        dp[i + 1, j + 1] <- min(
+          dp[i, j + 1] + 1,   # Deletion
+          dp[i + 1, j] + 1,   # Insertion
+          dp[i, j] + 1        # Substitution
+        )
+      }
+    }
+  }
+  
+  return(dp[n + 1, m + 1])
+}
+
+# Interactive input
+s1 <- tolower(readline("Enter first string: "))
+s2 <- tolower(readline("Enter second string: "))
+
+distance <- levenshtein_distance(s1, s2)
+cat("Levenshtein distance between '", s1, "' and '", s2, "' is:", distance, "\n")

--- a/__sql2/lfu_test.go
+++ b/__sql2/lfu_test.go
@@ -1,0 +1,58 @@
+package cache_test
+
+import (
+	"testing"
+
+	"github.com/TheAlgorithms/Go/cache"
+)
+
+func TestLFU(t *testing.T) {
+	lfuCache := cache.NewLFU(3)
+	t.Run("Test 1: Put number and Get is correct", func(t *testing.T) {
+		key, value := "1", 1
+		lfuCache.Put(key, value)
+		got := lfuCache.Get(key)
+
+		if got != value {
+			t.Errorf("expected: %v, got: %v", value, got)
+		}
+	})
+
+	t.Run("Test 2: Get data not stored in cache should return nil", func(t *testing.T) {
+		got := lfuCache.Get("2")
+		if got != nil {
+			t.Errorf("expected: nil, got: %v", got)
+		}
+	})
+
+	t.Run("Test 3: Put data over capacity and Get should return nil", func(t *testing.T) {
+		lfuCache.Put("2", 2)
+		lfuCache.Put("3", 3)
+		lfuCache.Put("4", 4)
+
+		got := lfuCache.Get("1")
+		if got != nil {
+			t.Errorf("expected: nil, got: %v", got)
+		}
+	})
+
+	t.Run("test 4: Put key over capacity but recent key exists", func(t *testing.T) {
+		lfuCache.Put("4", 4)
+		lfuCache.Put("3", 3)
+		lfuCache.Put("2", 2)
+		lfuCache.Put("1", 1)
+
+		got := lfuCache.Get("4")
+		if got != nil {
+			t.Errorf("expected: nil, got: %v", got)
+		}
+
+		expected := 3
+		got = lfuCache.Get("3")
+
+		if got != expected {
+			t.Errorf("expected: %v, got: %v", expected, got)
+		}
+
+	})
+}

--- a/__sql2/number_of_digits.test.ts
+++ b/__sql2/number_of_digits.test.ts
@@ -1,0 +1,22 @@
+import { numberOfDigits } from '../number_of_digits'
+
+describe('numberOfDigits', () => {
+  test.each([-890, -5.56, -7, 0, 0.73, 4.2, NaN, -Infinity, Infinity])(
+    'should throw an error for non natural number %d',
+    (num) => {
+      expect(() => numberOfDigits(num)).toThrowError(
+        'only natural numbers are supported'
+      )
+    }
+  )
+
+  test.each([
+    [1, 1],
+    [18, 2],
+    [549, 3],
+    [7293, 4],
+    [1234567890, 10]
+  ])('of %i should be %i', (num, expected) => {
+    expect(numberOfDigits(num)).toBe(expected)
+  })
+})


### PR DESCRIPTION
Adding lfu_test.go levenshtein.r number_of_digits.test.ts